### PR TITLE
Add Branch component

### DIFF
--- a/packages/branch/README.md
+++ b/packages/branch/README.md
@@ -1,0 +1,19 @@
+# Branch
+
+### Overview
+
+The Branch component is useful for running any of its child components on specified Git branches.
+
+### Valid Props
+
+| Name | Type   | Example  | Notes                               |
+| :--- | :----- | :------- | :---------------------------------- |
+| when | string | ^master$ | Should be a valid RegExp expression |
+
+### Example Usage
+
+```js
+<Branch when="^master$">
+  <Run command="echo on master branch!" />
+</Branch>
+```

--- a/packages/branch/package.json
+++ b/packages/branch/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@sailci/psx-components-branch",
+  "version": "0.1.0",
+  "main": "lib/index.js",
+  "license": "MIT",
+  "scripts": {},
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/branch/src/index.js
+++ b/packages/branch/src/index.js
@@ -1,0 +1,20 @@
+export default {
+  execute: async ({ when }, context, next) => {
+    if (!process.env.GIT_BRANCH) {
+      throw new Error(
+        '"Branch" component requires GIT_BRANCH environment variable to be set',
+      );
+    }
+
+    const whenRegExp = new RegExp(when);
+
+    if (whenRegExp.test(process.env.GIT_BRANCH)) {
+      await next();
+    }
+  },
+  validate: ({ when }) => {
+    if (typeof when !== 'string') {
+      throw new Error('"when" of "Branch" can only be a "string"');
+    }
+  },
+};

--- a/packages/branch/src/index.test.js
+++ b/packages/branch/src/index.test.js
@@ -1,0 +1,80 @@
+describe('Branch component', () => {
+  let Branch;
+
+  afterEach(() => {
+    process.env.GIT_BRANCH = undefined;
+    jest.resetModules();
+  });
+
+  describe('#execute', () => {
+    let nextMock;
+
+    describe('when "GIT_BRANCH" environment variable is missing', () => {
+      beforeEach(() => {
+        nextMock = jest.fn(() => Promise.resolve());
+
+        Branch = require('.').default;
+      });
+
+      it('throws error', async () => {
+        expect(
+          Branch.execute({ when: '^master$' }, {}, nextMock),
+        ).rejects.toThrow(
+          '"Branch" component requires GIT_BRANCH environment variable to be set',
+        );
+      });
+    });
+
+    describe('when "GIT_BRANCH" environment variable is present', () => {
+      beforeEach(() => {
+        process.env.GIT_BRANCH = undefined;
+      });
+
+      describe('when "when" matches current branch', () => {
+        beforeEach(() => {
+          process.env.GIT_BRANCH = 'master';
+
+          nextMock = jest.fn(() => Promise.resolve());
+
+          Branch = require('.').default;
+        });
+
+        it('calls next', async () => {
+          await Branch.execute({ when: '^master$' }, {}, nextMock);
+
+          expect(nextMock).toHaveBeenCalled();
+        });
+      });
+
+      describe('when "when" does not match current branch', () => {
+        beforeEach(() => {
+          process.env.GIT_BRANCH = 'master';
+
+          nextMock = jest.fn(() => Promise.resolve());
+
+          Branch = require('.').default;
+        });
+
+        it('calls next', async () => {
+          await Branch.execute({ when: '^develop$' }, {}, nextMock);
+
+          expect(nextMock).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe('#validate', () => {
+    beforeEach(() => {
+      Branch = require('.').default;
+    });
+
+    it('does not throw an error when "when" is a string', () => {
+      expect(() => Branch.validate({ when: '/master/' })).not.toThrow();
+    });
+
+    it('throws an error when "when" is not a string', () => {
+      expect(() => Branch.validate({ when: 1 })).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
The Branch component accepts a `when` prop that takes a string. This string is parsed into a RegExp and then uses the `GIT_BRANCH` environment variable to see if the current branch satisfies the condition.

Some thoughts/questions:
* Should the `GIT_BRANCH` env var be changeable? Should another prop be used to say what it might be called?
* Do we need an `except` prop so it's easy to specify the reverse of `when`? For example, when you want something to run on every branch except master. Might make it easier for people to use since negative RegExp can get difficult.
  * If we do have an `except` prop do we run the `when` test first and then `except` test?