### PR TITLE
Updates to Run component

### DIFF
--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -8,7 +8,7 @@ The Run component is a general purpose command that executes relevant shell / te
 
 | Name    | Type   | Example            |
 | :------ | :----- | :----------------- |
-| command | string | echo Hello, world! |
+| command | string | echo Hello World   |
 
 ### Example Usage
 

--- a/packages/run/README.md
+++ b/packages/run/README.md
@@ -9,7 +9,6 @@ The Run component is a general purpose command that executes relevant shell / te
 | Name    | Type   | Example            |
 | :------ | :----- | :----------------- |
 | command | string | echo Hello, world! |
-|         |        |                    |
 
 ### Example Usage
 

--- a/packages/run/src/index.js
+++ b/packages/run/src/index.js
@@ -1,15 +1,8 @@
-/* eslint-disable no-console */
 import exec from './exec';
 
 export default {
   execute: async ({ command }) => {
-    try {
-      await exec(command);
-    } catch (err) {
-      console.log(err.message);
-
-      throw err;
-    }
+    await exec(command);
   },
   validate: ({ command }) => {
     if (typeof command !== 'string') {

--- a/packages/run/src/index.test.js
+++ b/packages/run/src/index.test.js
@@ -28,21 +28,13 @@ describe('Run component', () => {
     });
 
     describe('when command is unsuccessful', () => {
-      let consoleSpy;
-
       beforeEach(() => {
         execMock = jest.fn(() =>
           Promise.reject(new Error('The command failed.')),
         );
         jest.doMock('./exec', () => execMock);
 
-        consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-
         Run = require('.').default;
-      });
-
-      afterEach(() => {
-        consoleSpy.mockRestore();
       });
 
       it('throws an error', () => {
@@ -51,16 +43,6 @@ describe('Run component', () => {
             command: 'yarn',
           }),
         ).rejects.toThrow('The command failed.');
-      });
-
-      it('shows a console log for the user', async () => {
-        try {
-          await Run.execute({ command: 'yarn' });
-        } catch (err) {
-          //empty
-        }
-
-        expect(consoleSpy).toHaveBeenCalledWith('The command failed.');
       });
     });
   });


### PR DESCRIPTION
Run component was logging the error message and then throwing it again. Since the executor will log any error that caused a failure it causes the error to be output twice. 

* Remove logging from the Run component
* Remove extra line in table of docs